### PR TITLE
add uart to usb bridge to make it one stop solution for usb -> common io

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,10 @@ project(dln2_project)
 pico_sdk_init()
 
 add_executable(dln2
-	main.c
-	usb_descriptors.c
-	driver.c
+    main.c
+    uart.c
+    usb_descriptors.c
+    driver.c
     dln2.c
     dln2-pin.c
     dln2-gpio.c
@@ -24,5 +25,5 @@ add_executable(dln2
 
 target_include_directories(dln2 PRIVATE ${CMAKE_CURRENT_LIST_DIR})
 
-target_link_libraries(dln2 PRIVATE pico_stdlib tinyusb_device tinyusb_board pico_unique_id hardware_gpio hardware_i2c hardware_spi hardware_adc)
+target_link_libraries(dln2 PRIVATE pico_stdlib tinyusb_device tinyusb_board pico_unique_id hardware_gpio hardware_i2c hardware_spi hardware_adc pico_multicore)
 pico_add_extra_outputs(dln2)

--- a/dln2-adc.c
+++ b/dln2-adc.c
@@ -15,7 +15,7 @@
 #include "hardware/adc.h"
 #include "dln2.h"
 
-#define LOG1    printf
+#define LOG1    //printf
 
 #define DLN2_ADC_CMD(cmd)   ((DLN2_MODULE_ADC << 8) | (cmd))
 

--- a/dln2-pin.c
+++ b/dln2-pin.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include "dln2.h"
 
-#define LOG1    printf
+#define LOG1    //printf
 
 #define DLN2_PIN_MAX    32
 #define DLN2_PIN_NOT_AVAILABLE  0xff

--- a/dln2.c
+++ b/dln2.c
@@ -220,7 +220,7 @@ bool dln2_response_u32(struct dln2_slot *slot, uint32_t val)
 
 bool dln2_response_error(struct dln2_slot *slot, uint16_t result)
 {
-    //printf("%s: handle=%u: result=0x%x (%u)\n", __func__, dln2_slot_header(slot)->handle, result, result);
+    LOG1("%s: handle=%u: result=0x%x (%u)\n", __func__, dln2_slot_header(slot)->handle, result, result);
     return _dln2_response(slot, 0, result);
 }
 

--- a/i2c-at24-flash.c
+++ b/i2c-at24-flash.c
@@ -16,8 +16,8 @@
 #include "hardware/sync.h"
 #include "i2c-at24.h"
 
-#define LOG1    printf
-#define LOG2    printf
+#define LOG1    //printf
+#define LOG2    //printf
 
 
 //#define PICO_FLASH_SIZE_BYTES (2 * 1024 * 1024)
@@ -68,7 +68,7 @@ static void flash_print_header(const struct at24_flash_header *hdr)
     for (uint i = 0; i < sizeof(hdr->pad_zero); i++)
         pad_zero |= hdr->pad_zero[i];
 
-    printf("%u: magic=%s wear=%llu version=%llu address=0x%02x pad_zero=%s checksum=%u\n",
+    LOG1("%u: magic=%s wear=%llu version=%llu address=0x%02x pad_zero=%s checksum=%u\n",
            flash_sector_index(hdr), hdr->magic == AT24_FLASH_HEADER_MAGIC ? "yes" : "no",
            hdr->wear, hdr->version, hdr->address, pad_zero ? "no" : "yes", hdr->checksum);
 }
@@ -117,7 +117,7 @@ static const struct at24_flash_sector *find_flash_sector(uint16_t address)
     uint64_t version = 0;
     uint32_t flash_offs;
 
-    //printf("%s: address=0x%02x\n", __func__, address);
+    LOG1("%s: address=0x%02x\n", __func__, address);
 
     flash_for_each_sector(flash_offs, 0) {
         const struct at24_flash_sector *sector = flash_address(flash_offs);
@@ -184,12 +184,12 @@ static uint32_t find_free_flash_sector(uint64_t *wear)
     for (uint i = 0; i < num_addresses; i++) {
         uint64_t version = 0;
 
-        //printf("  try address: 0x%02x\n", addresses[i]);
+        LOG1("  try address: 0x%02x\n", addresses[i]);
 
         // Find the current version so we know which one to ignore
         sector = find_flash_sector(addresses[i]);
         version = sector->header.version;
-        //printf("    version=%llu\n", version);
+        LOG1("    version=%llu\n", version);
 
         // Find the sector with the least wear that is not in use
         flash_for_each_sector(flash_offs, 0) {

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -17,8 +17,8 @@
 
 #define CFG_DLN2_BULK_ENPOINT_SIZE  64
 
-//#undef CFG_TUSB_DEBUG
-//#define CFG_TUSB_DEBUG              2
+#undef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG              0
 
 #define CFG_TUD_CDC 2
 

--- a/tusb_config.h
+++ b/tusb_config.h
@@ -20,4 +20,23 @@
 //#undef CFG_TUSB_DEBUG
 //#define CFG_TUSB_DEBUG              2
 
+#define CFG_TUD_CDC 2
+
+#define CFG_TUD_CDC_RX_BUFSIZE 1024
+#define CFG_TUD_CDC_TX_BUFSIZE 1024
+#define USBD_CDC_CMD_MAX_SIZE 8
+#define USBD_CDC_IN_OUT_MAX_SIZE 64
+
+#define USBD_CDC_0_EP_CMD 0x81
+#define USBD_CDC_1_EP_CMD 0x83
+
+#define USBD_CDC_0_EP_OUT 0x01
+#define USBD_CDC_1_EP_OUT 0x03
+
+#define USBD_CDC_0_EP_IN 0x82
+#define USBD_CDC_1_EP_IN 0x84
+
+#define USBD_DLN_EP_IN 0x89
+#define USBD_DLN_EP_OUT 0x09
+
 #endif /* _TUSB_CONFIG_H_ */

--- a/uart.c
+++ b/uart.c
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Copyright 2021 Álvaro Fernández Rojas <noltari@gmail.com>
+ */
+/* https://github.com/Noltari/pico-uart-bridge */
+
+#include <hardware/irq.h>
+#include <hardware/structs/sio.h>
+#include <hardware/uart.h>
+#include <pico/multicore.h>
+#include <pico/stdlib.h>
+#include <string.h>
+#include <tusb.h>
+
+#include "uart.h"
+
+#if !defined(MIN)
+#define MIN(a, b) ((a > b) ? b : a)
+#endif /* MIN */
+
+#define BUFFER_SIZE 2560
+
+#define DEF_BIT_RATE 115200
+#define DEF_STOP_BITS 1
+#define DEF_PARITY 0
+#define DEF_DATA_BITS 8
+
+typedef struct {
+    uart_inst_t *const inst;
+    uint irq;
+    void *irq_fn;
+    uint8_t tx_pin;
+    uint8_t rx_pin;
+} uart_id_t;
+
+typedef struct {
+    cdc_line_coding_t usb_lc;
+    cdc_line_coding_t uart_lc;
+    mutex_t lc_mtx;
+    uint8_t uart_buffer[BUFFER_SIZE];
+    uint32_t uart_pos;
+    mutex_t uart_mtx;
+    uint8_t usb_buffer[BUFFER_SIZE];
+    uint32_t usb_pos;
+    mutex_t usb_mtx;
+} uart_data_t;
+
+void uart0_irq_fn(void);
+void uart1_irq_fn(void);
+
+const uart_id_t UART_ID[NUM_UART_IFCE] = {
+    {
+        .inst = uart0,
+        .irq = UART0_IRQ,
+        .irq_fn = &uart0_irq_fn,
+        .tx_pin = UART0_TX,
+        .rx_pin = UART0_RX,
+    }, {
+        .inst = uart1,
+        .irq = UART1_IRQ,
+        .irq_fn = &uart1_irq_fn,
+        .tx_pin = UART1_TX,
+        .rx_pin = UART1_RX,
+    }
+};
+
+uart_data_t UART_DATA[NUM_UART_IFCE];
+
+static inline uint databits_usb2uart(uint8_t data_bits)
+{
+    switch (data_bits) {
+        case 5:
+            return 5;
+        case 6:
+            return 6;
+        case 7:
+            return 7;
+        default:
+            return 8;
+    }
+}
+
+static inline uart_parity_t parity_usb2uart(uint8_t usb_parity)
+{
+    switch (usb_parity) {
+        case 1:
+            return UART_PARITY_ODD;
+        case 2:
+            return UART_PARITY_EVEN;
+        default:
+            return UART_PARITY_NONE;
+    }
+}
+
+static inline uint stopbits_usb2uart(uint8_t stop_bits)
+{
+    switch (stop_bits) {
+        case 2:
+            return 2;
+        default:
+            return 1;
+    }
+}
+
+void update_uart_cfg(uint8_t itf)
+{
+    const uart_id_t *ui = &UART_ID[itf];
+    uart_data_t *ud = &UART_DATA[itf];
+
+    mutex_enter_blocking(&ud->lc_mtx);
+
+    if (ud->usb_lc.bit_rate != ud->uart_lc.bit_rate) {
+        uart_set_baudrate(ui->inst, ud->usb_lc.bit_rate);
+        ud->uart_lc.bit_rate = ud->usb_lc.bit_rate;
+    }
+
+    if ((ud->usb_lc.stop_bits != ud->uart_lc.stop_bits) ||
+        (ud->usb_lc.parity != ud->uart_lc.parity) ||
+        (ud->usb_lc.data_bits != ud->uart_lc.data_bits)) {
+        uart_set_format(ui->inst,
+                databits_usb2uart(ud->usb_lc.data_bits),
+                stopbits_usb2uart(ud->usb_lc.stop_bits),
+                parity_usb2uart(ud->usb_lc.parity));
+        ud->uart_lc.data_bits = ud->usb_lc.data_bits;
+        ud->uart_lc.parity = ud->usb_lc.parity;
+        ud->uart_lc.stop_bits = ud->usb_lc.stop_bits;
+    }
+
+    mutex_exit(&ud->lc_mtx);
+}
+
+void usb_read_bytes(uint8_t itf)
+{
+    uart_data_t *ud = &UART_DATA[itf];
+    uint32_t len = tud_cdc_n_available(itf);
+
+    if (len &&
+        mutex_try_enter(&ud->usb_mtx, NULL)) {
+        len = MIN(len, BUFFER_SIZE - ud->usb_pos);
+        if (len) {
+            uint32_t count;
+
+            count = tud_cdc_n_read(itf, &ud->usb_buffer[ud->usb_pos], len);
+            ud->usb_pos += count;
+        }
+
+        mutex_exit(&ud->usb_mtx);
+    }
+}
+
+void usb_write_bytes(uint8_t itf)
+{
+    uart_data_t *ud = &UART_DATA[itf];
+
+    if (ud->uart_pos &&
+        mutex_try_enter(&ud->uart_mtx, NULL)) {
+        uint32_t count;
+
+        count = tud_cdc_n_write(itf, ud->uart_buffer, ud->uart_pos);
+        if (count < ud->uart_pos)
+            memcpy(ud->uart_buffer, &ud->uart_buffer[count],
+                    ud->uart_pos - count);
+        ud->uart_pos -= count;
+
+        mutex_exit(&ud->uart_mtx);
+
+        if (count)
+            tud_cdc_n_write_flush(itf);
+    }
+}
+
+void usb_cdc_process(uint8_t itf)
+{
+    uart_data_t *ud = &UART_DATA[itf];
+
+    mutex_enter_blocking(&ud->lc_mtx);
+    tud_cdc_n_get_line_coding(itf, &ud->usb_lc);
+    mutex_exit(&ud->lc_mtx);
+
+    usb_read_bytes(itf);
+    usb_write_bytes(itf);
+}
+
+void core1_entry(void)
+{
+    tusb_init();
+
+    while (1) {
+        int itf;
+        int con = 0;
+
+        tud_task();
+
+        for (itf = 0; itf < NUM_UART_IFCE; itf++) {
+            if (tud_cdc_n_connected(itf)) {
+                con = 1;
+                usb_cdc_process(itf);
+            }
+        }
+
+    }
+}
+
+static inline void uart_read_bytes(uint8_t itf)
+{
+    uart_data_t *ud = &UART_DATA[itf];
+    const uart_id_t *ui = &UART_ID[itf];
+
+    if (uart_is_readable(ui->inst)) {
+        mutex_enter_blocking(&ud->uart_mtx);
+
+        while (uart_is_readable(ui->inst) &&
+            (ud->uart_pos < BUFFER_SIZE)) {
+            ud->uart_buffer[ud->uart_pos] = uart_getc(ui->inst);
+            ud->uart_pos++;
+        }
+
+        mutex_exit(&ud->uart_mtx);
+    }
+}
+
+void uart0_irq_fn(void)
+{
+    uart_read_bytes(0);
+}
+
+void uart1_irq_fn(void)
+{
+    uart_read_bytes(1);
+}
+
+void uart_write_bytes(uint8_t itf)
+{
+    uart_data_t *ud = &UART_DATA[itf];
+
+    if (ud->usb_pos &&
+        mutex_try_enter(&ud->usb_mtx, NULL)) {
+        const uart_id_t *ui = &UART_ID[itf];
+        uint32_t count = 0;
+
+        while (uart_is_writable(ui->inst) &&
+               count < ud->usb_pos) {
+            uart_putc_raw(ui->inst, ud->usb_buffer[count]);
+            count++;
+        }
+
+        if (count < ud->usb_pos)
+            memcpy(ud->usb_buffer, &ud->usb_buffer[count],
+                   ud->usb_pos - count);
+        ud->usb_pos -= count;
+
+        mutex_exit(&ud->usb_mtx);
+    }
+}
+
+void init_uart_data(uint8_t itf)
+{
+    const uart_id_t *ui = &UART_ID[itf];
+    uart_data_t *ud = &UART_DATA[itf];
+
+    /* Pinmux */
+    gpio_set_function(ui->tx_pin, GPIO_FUNC_UART);
+    gpio_set_function(ui->rx_pin, GPIO_FUNC_UART);
+
+    /* USB CDC LC */
+    ud->usb_lc.bit_rate = DEF_BIT_RATE;
+    ud->usb_lc.data_bits = DEF_DATA_BITS;
+    ud->usb_lc.parity = DEF_PARITY;
+    ud->usb_lc.stop_bits = DEF_STOP_BITS;
+
+    /* UART LC */
+    ud->uart_lc.bit_rate = DEF_BIT_RATE;
+    ud->uart_lc.data_bits = DEF_DATA_BITS;
+    ud->uart_lc.parity = DEF_PARITY;
+    ud->uart_lc.stop_bits = DEF_STOP_BITS;
+
+    /* Buffer */
+    ud->uart_pos = 0;
+    ud->usb_pos = 0;
+
+    /* Mutex */
+    mutex_init(&ud->lc_mtx);
+    mutex_init(&ud->uart_mtx);
+    mutex_init(&ud->usb_mtx);
+
+    /* UART start */
+    uart_init(ui->inst, ud->usb_lc.bit_rate);
+    uart_set_hw_flow(ui->inst, false, false);
+    uart_set_format(ui->inst, databits_usb2uart(ud->usb_lc.data_bits),
+            stopbits_usb2uart(ud->usb_lc.stop_bits),
+            parity_usb2uart(ud->usb_lc.parity));
+    uart_set_fifo_enabled(ui->inst, false);
+
+    /* UART RX Interrupt */
+    irq_set_exclusive_handler(ui->irq, ui->irq_fn);
+    irq_set_enabled(ui->irq, true);
+    uart_set_irq_enables(ui->inst, true, false);
+}

--- a/uart.h
+++ b/uart.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Copyright 2021 Álvaro Fernández Rojas <noltari@gmail.com>
+ */
+
+#define UART0_TX 0
+#define UART0_RX 1
+#define UART1_TX 8
+#define UART1_RX 9
+#define NUM_UART_IFCE 2
+
+void update_uart_cfg(uint8_t itf);
+void uart_write_bytes(uint8_t itf);
+void init_uart_data(uint8_t itf);
+void core1_entry(void);

--- a/usb_descriptors.c
+++ b/usb_descriptors.c
@@ -19,7 +19,17 @@ enum string_index {
     MANUFACTURER_IDX,
     PRODUCT_IDX,
     SERIALNUMBER_IDX,
-    DLN2_INTERFACE_IDX,
+    DLN2_INTERFACE_NAME_IDX,
+    CDC_NAME_IDX,
+};
+
+enum interface_index {
+    DLN_IFCE = 0,
+    CDC1_CMD_IFCE,
+    CDC1_DATA_IFCE,
+    CDC2_CMD_IFCE,
+    CDC2_DATA_IFCE,
+    MAX_N_IFCE,
 };
 
 tusb_desc_device_t const device_descriptor = {
@@ -27,7 +37,7 @@ tusb_desc_device_t const device_descriptor = {
     .bDescriptorType    = TUSB_DESC_DEVICE,
     .bcdUSB          	= 0x0110,
 
-    .bDeviceClass    	= TUSB_CLASS_VENDOR_SPECIFIC,
+    .bDeviceClass    	= 0,
     .bDeviceSubClass 	= 0,
     .bDeviceProtocol 	= 0,
     .bMaxPacketSize0 	= 64,
@@ -60,27 +70,31 @@ uint8_t const *tud_descriptor_device_cb(void)
 
 typedef struct TU_ATTR_PACKED {
     tusb_desc_configuration_t config;
-    tusb_desc_interface_t interface;
-    tusb_desc_endpoint_t bulk_out;
-    tusb_desc_endpoint_t bulk_in;
+    tusb_desc_interface_t dln_interface;
+    tusb_desc_endpoint_t dln_bulk_out;
+    tusb_desc_endpoint_t dln_bulk_in;
+    u_int8_t cdc1_ifce_desc[TUD_CDC_DESC_LEN];
+    u_int8_t cdc2_ifce_desc[TUD_CDC_DESC_LEN];
 } usbtest_source_sink_config_descriptor_t;
+
+
 
 usbtest_source_sink_config_descriptor_t source_sink_config_descriptor = {
     .config = {
         .bLength = sizeof(tusb_desc_configuration_t),
         .bDescriptorType = TUSB_DESC_CONFIGURATION,
         .wTotalLength = sizeof(usbtest_source_sink_config_descriptor_t),
-        .bNumInterfaces = 1,
+        .bNumInterfaces = MAX_N_IFCE,
         .bConfigurationValue = 1,
-        .iConfiguration = DLN2_INTERFACE_IDX,
+        .iConfiguration = DLN2_INTERFACE_NAME_IDX,
         .bmAttributes = TU_BIT(7) | TUSB_DESC_CONFIG_ATT_SELF_POWERED,
         .bMaxPower = 100 / 2,
     },
 
-    .interface = {
+    .dln_interface = {
         .bLength = sizeof(tusb_desc_interface_t),
         .bDescriptorType = TUSB_DESC_INTERFACE,
-        .bInterfaceNumber = 0,
+        .bInterfaceNumber = DLN_IFCE,
         .bAlternateSetting = 0,
         .bNumEndpoints = 2,
         .bInterfaceClass = TUSB_CLASS_VENDOR_SPECIFIC,
@@ -89,8 +103,20 @@ usbtest_source_sink_config_descriptor_t source_sink_config_descriptor = {
         .iInterface = 0,
     },
 
-    .bulk_out = DLN2_BULK_DESCRIPTOR(0x01),
-    .bulk_in = DLN2_BULK_DESCRIPTOR(0x81),
+    .dln_bulk_out = DLN2_BULK_DESCRIPTOR(USBD_DLN_EP_OUT),
+    .dln_bulk_in = DLN2_BULK_DESCRIPTOR(USBD_DLN_EP_IN),
+
+    .cdc1_ifce_desc = {
+        TUD_CDC_DESCRIPTOR(CDC1_CMD_IFCE, CDC_NAME_IDX,
+            USBD_CDC_0_EP_CMD, USBD_CDC_CMD_MAX_SIZE,
+            USBD_CDC_0_EP_OUT, USBD_CDC_0_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE)
+    },
+
+    .cdc2_ifce_desc = {
+        TUD_CDC_DESCRIPTOR(CDC2_CMD_IFCE, CDC_NAME_IDX,
+            USBD_CDC_1_EP_CMD, USBD_CDC_CMD_MAX_SIZE,
+            USBD_CDC_1_EP_OUT, USBD_CDC_1_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE)
+    },
 };
 
 uint8_t const * tud_descriptor_configuration_cb(uint8_t index)
@@ -128,8 +154,10 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
     } else if (index == SERIALNUMBER_IDX) {
         pico_get_unique_board_id_string(serial, sizeof(serial));
         str = serial;
-    } else if (index == DLN2_INTERFACE_IDX) {
+    } else if (index == DLN2_INTERFACE_NAME_IDX) {
         str = "DLN2";
+    } else if (index == CDC_NAME_IDX) {
+        str = "Pico USB CDC";
     } else {
         return NULL;
     }


### PR DESCRIPTION
Used some MIT licensed code to add usb->uart function. Added 2 cdc usb interface corresponding to the 2 uart hardware in pico.

The debug is disabled all the way so that it does not pollute uart0.

It is also possible to add one additional cdc interface so that the debug can be run independently of the uart, but one downside is that the host might not be able to connect to the cdc interface when pico boots. But I am open to suggestions/request for this feature.